### PR TITLE
Feature - Add Auction Winner Determination Service

### DIFF
--- a/src/models/Bid.ts
+++ b/src/models/Bid.ts
@@ -1,0 +1,4 @@
+export interface Bid {
+  bidderId: string | null,
+  price: number,
+}

--- a/src/services/AuctionWinnerService.test.ts
+++ b/src/services/AuctionWinnerService.test.ts
@@ -1,0 +1,96 @@
+import { Bid } from '../models/Bid';
+import { DeterminWinningBidderAndPrice } from './AuctionWinnerService';
+
+describe('the DeterminWinningBidderAndPrice function', () => {
+  it('returns null as the winning bidder if no bids above reserve price', () => {
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 90 },
+      { bidderId: 'B', price: 90 },
+      { bidderId: 'C', price: 90 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(100, bids);
+
+    expect(result.bidderId).toBeNull();
+  });
+
+  it('returns the reserve price if only one bidder is above the reserve price', () => {
+    const reservePrice = 100;
+
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 120 },
+      { bidderId: 'A', price: 110 },
+      { bidderId: 'B', price: 90 },
+      { bidderId: 'C', price: 90 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(reservePrice, bids);
+
+    expect(result.bidderId).toBe('A');
+    expect(result.price).toBe(reservePrice);
+  });
+
+  it('returns the highest bidder id if multiple bids above reserve price', () => {
+    
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 120 },
+      { bidderId: 'B', price: 110 },
+      { bidderId: 'C', price: 130 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(100, bids);
+
+    expect(result.bidderId).toBe('C');
+  });
+
+  it('returns the highest price from the non-winning buyer id if multiple bids above reserve price', () => {
+    
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 130 },
+      { bidderId: 'A', price: 140 },
+      { bidderId: 'B', price: 110 },
+      { bidderId: 'C', price: 120 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(100, bids);
+
+    expect(result.price).toBe(120);
+  });
+
+  test('if two bidders place the same highest bid, it returns the first bidder seen', () => {
+    
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 130 },
+      { bidderId: 'A', price: 140 },
+      { bidderId: 'B', price: 110 },
+      { bidderId: 'C', price: 140 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(100, bids);
+
+    expect(result.bidderId).toBe('A');
+    expect(result.price).toBe(140);
+  });
+
+  it('correctly returns the expected result from the example test case', () => {
+    const bids: Bid[] = [
+      { bidderId: 'A', price: 110 },
+      { bidderId: 'A', price: 130 },
+      // No Bids from "B"
+      { bidderId: 'C', price: 125 },
+      { bidderId: 'D', price: 105 },
+      { bidderId: 'D', price: 115 },
+      { bidderId: 'D', price: 90 },
+      { bidderId: 'E', price: 132 },
+      { bidderId: 'E', price: 135 },
+      { bidderId: 'E', price: 140 },
+    ];
+    
+    const result = DeterminWinningBidderAndPrice(100, bids);
+
+    expect(result.bidderId).toBe('E');
+    expect(result.price).toBe(130);
+  });
+
+})
+

--- a/src/services/AuctionWinnerService.ts
+++ b/src/services/AuctionWinnerService.ts
@@ -1,0 +1,35 @@
+import { Bid } from '../models/Bid';
+
+function DeterminWinningBidderAndPrice(floor: number, bids: Bid[]): Bid {
+  // Set highest and second highest bids to be bids without a bidder at the floor price.
+  // This will allow us to easily filter out bids below the floor price.
+  let highestBid: Bid = {
+    bidderId: null,
+    price: floor,
+  };
+  let secondHighestBid = highestBid;
+
+  // Loop through each bid.
+  bids.forEach( bid => {
+    // First check and see if this bid's price is higher than the current highest bid.
+    if (bid.price > highestBid.price) {
+      // If this is a bid from a new person, make the current highest bid the second highest bid.
+      if (bid.bidderId !== highestBid.bidderId) {
+        secondHighestBid = highestBid;
+      }
+      highestBid = bid;
+    } else if (bid.price > secondHighestBid.price && bid.bidderId != highestBid.bidderId) {
+      // If this bid's price is higher than the current second highest bid and the bidder is not the same as the highest bid,
+      // set the second highest bid to the current bid.
+      secondHighestBid = bid;
+    }
+  });
+
+  // Return a new bid object containing the highest bidder and the price from the second highest bid.
+  return {
+    bidderId: highestBid.bidderId,
+    price: secondHighestBid.price,
+  };
+}
+
+export { DeterminWinningBidderAndPrice };


### PR DESCRIPTION
## Why is this change happening?

This is the main foudation of this example repository.  This service can receive a list of bids and a floor price and will return the winning bidder and price to be paid.  It follows standard [vickrey auction](https://en.wikipedia.org/wiki/Vickrey_auction) logic whereby the winner of the auction is the highest bidder above the floor, and the price paid is the highest bid above the floor by a losing bidder.

## How is this tested?

I have unit tests around the service covering (hopefully) all cases.
